### PR TITLE
feature : 매수,매도 내역 저장 기능 구현

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -10,7 +10,7 @@ const subTransactionHistorySchema = new mongoose.Schema({
     type: String,
     required: true,
   },
-  unitsTrade: {
+  unitsTraded: {
     type: Number,
     required: true,
   },
@@ -39,7 +39,6 @@ const subAssetSchema = new mongoose.Schema({
     {
       currencyName: {
         type: String,
-        required: true,
       },
       quantity: {
         type: Number,

--- a/routes/users.js
+++ b/routes/users.js
@@ -3,8 +3,6 @@ const router = express.Router();
 const User = require("../models/User");
 const verifyToken = require("../middlewares/verifyToken");
 
-const verifyToken = require("../middlewares/verifyToken");
-
 router.get(
   "/transaction-history/:userid",
   verifyToken,
@@ -21,11 +19,12 @@ router.get(
   }
 );
 
-router.post("/candlestick", async function (req, res, next) {
-  const { candlestick, email } = req.body.headers;
+router.post("/candlestick/:userid", async function (req, res, next) {
+  const { userid } = req.params;
+  const { candlestick } = req.body;
 
   try {
-    await User.findOneAndUpdate({ email }, { candlestick });
+    await User.findByIdAndUpdate(userid, { candlestick });
 
     res.status(201).send({ result: "candlestick save success" });
   } catch (err) {
@@ -34,12 +33,78 @@ router.post("/candlestick", async function (req, res, next) {
 });
 
 router.get("/asset/:userid", verifyToken, async function (req, res, next) {
-  const { userId } = req.params;
+  const { userid } = req.params;
 
   try {
-    const user = await User.findById({ _id: userId }).lean().exec();
+    const user = await User.findById({ _id: userid }).lean().exec();
 
     res.status(200).send({ userAsset: user });
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.post("/order/:userid", verifyToken, async function (req, res, next) {
+  try {
+    const { userid } = req.params;
+    const { currencyName, unitsTraded, total } = req.body;
+    const { transactionHistory, asset } = await User.findById(userid)
+      .lean()
+      .exec();
+
+    delete req.body.authorization;
+    const newTransactionHistory = req.body;
+    transactionHistory.push(newTransactionHistory);
+
+    const userCash = asset.cash;
+    const updatedUserCash = userCash + total;
+
+    const userCoins = asset.coins;
+
+    let coinIndex = null;
+    for (let i = 0; i < userCoins.length; i++) {
+      if (userCoins[i].currencyName === currencyName) {
+        coinIndex = i;
+        break;
+      }
+    }
+
+    if (coinIndex === null) {
+      const newCoin = {
+        currencyName: currencyName,
+        quantity: unitsTraded,
+        averagePrice: total / unitsTraded,
+      };
+
+      userCoins.push(newCoin);
+
+      await User.findByIdAndUpdate(userid, {
+        transactionHistory: transactionHistory,
+        asset: {
+          cash: updatedUserCash,
+          coins: userCoins,
+        },
+      }).exec();
+    } else {
+      const updatedQuantity = userCoins[coinIndex].quantity + unitsTraded;
+      const updatedAveragePrice =
+        (userCoins[coinIndex].quantity * userCoins[coinIndex].averagePrice +
+          total) /
+        updatedQuantity;
+
+      userCoins[coinIndex].quantity = updatedQuantity;
+      userCoins[coinIndex].averagePrice = updatedAveragePrice;
+
+      await User.findByIdAndUpdate(userid, {
+        transactionHistory: transactionHistory,
+        asset: {
+          cash: updatedUserCash,
+          coins: userCoins,
+        },
+      }).exec();
+    }
+
+    res.status(201).send({ result: "거래내역 및 자산 업데이트 성공" });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
# 매수, 매도 내역 저장 기능 구현

### [칸반링크](https://www.notion.so/vanillacoding/POST-users-order-userid-63b7fbef7b27452a88e017221dead775)

### 구현내용
 + 매수, 매도 내역을 서버 내 유저의 거래내역, 자산현황에 업데이트해 줍니다.

### 코드 설명
 + 유저 id로 서버에서 유저를 찾습니다.
 + 유저의 거래내역 리스트에 매수, 매도 내역을 추가해줍니다.
 + 매수, 매도 결과에 의한 유저의 현금 자산현황 변동을 업데이트 해줍니다.
 + 매수, 매도 결과에 의한 유저의 코인 자산현황 변동을 업데이트 해줍니다.

### 기타 설명
 + 유저 등록시 자산현황을 추가해주었습니다.
 + 유저 id 추가에 의해 candlestick POST 요청쪽에 수정이 있습니다.