### PR TITLE
feature: websocket 방식으로 빗썸 api 받아오기

### DIFF
--- a/socket.js
+++ b/socket.js
@@ -1,33 +1,26 @@
 const WebSocket = require("ws");
-const axios = require("axios");
+const wsModule = require("ws");
 
 module.exports = (server) => {
   const clientWss = new WebSocket.Server({ server });
+  const bithumbWs = new wsModule("wss://pubwss.bithumb.com/pub/ws");
   let coinInfo = null;
 
-  function getApi() {
-    const myCoin = "ALL";
+  const requestData = {
+    type: "ticker",
+    symbols: ["BTC_KRW", "ETH_KRW"],
+    tickTypes: ["24H"],
+  };
+  const subscribeData = JSON.stringify(requestData);
 
-    const tick = () => {
-      setTimeout(async () => {
-        try {
-          const response = await axios.get(
-            `https://api.bithumb.com/public/ticker/${myCoin}`
-          );
-          if (response.status === 200) {
-            coinInfo = response.data;
-          }
-        } catch (error) {
-          console.error(error);
-        }
+  bithumbWs.onopen = (ws) => {
+    bithumbWs.send(subscribeData);
+  };
 
-        tick();
-      }, 3000);
-    };
-    tick();
-  }
-
-  getApi();
+  bithumbWs.onmessage = (event) => {
+    coinInfo = event.data;
+    console.log("빗썸의 답::", coinInfo);
+  };
 
   clientWss.on("connection", (ws) => {
     ws.on("message", (message) => {
@@ -38,16 +31,10 @@ module.exports = (server) => {
       console.error(error);
     });
 
-    ws.on("close", () => {
-      clearInterval(ws.interval);
-    });
-
     ws.interval = () => {
       setTimeout(() => {
         try {
-          if (ws.readyState === ws.OPEN) {
-            ws.send(JSON.stringify(coinInfo));
-          }
+          ws.send(coinInfo);
         } catch (error) {
           console.error(error);
         }

--- a/socket.js
+++ b/socket.js
@@ -3,7 +3,7 @@ const wsModule = require("ws");
 
 module.exports = (server) => {
   const clientWss = new WebSocket.Server({ server });
-  const bithumbWs = new wsModule("wss://pubwss.bithumb.com/pub/ws");
+  const bithumbWs = new wsModule(process.env.BITHUMB_SOCKET_URL);
   let coinInfo = null;
 
   const requestData = {
@@ -40,7 +40,7 @@ module.exports = (server) => {
         }
 
         ws.interval();
-      }, 3000);
+      }, 2000);
     };
 
     ws.interval();


### PR DESCRIPTION
**구현 내용**
서버에서 빗썸 api 요청 방식 변경
재귀 setTimeout(기존) -> web socket(변경)

**설명**
socket.js
web socket 방식으로 빗썸 api 데이터를 받아오고 클라이언트로 전송해줍니다.