### PR TITLE
refactor: order post 요청 로직 수정

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -22,6 +22,10 @@ const subTransactionHistorySchema = new mongoose.Schema({
     type: Number,
     required: true,
   },
+  isBuy: {
+    type: Boolean,
+    required: true,
+  },
 });
 
 const subAssetSchema = new mongoose.Schema({


### PR DESCRIPTION
**구현 내용**
현재 프론트에서 매수 요청을 보내면 데이터베이스에 total 값이 -total로 저장되는 오류,
코인을 모두 팔았을 때 평균 매수가가 그대로 남아있는 오류가 있어 수정했습니다.

**설명**
프론트에서 매수 요청을 보냈을 때 데이터베이스에 -total로 저장되는 오류가 있었습니다.
이 오류를 해결하기 위해 프론트에서 요청을 보낼 때 매수 요청인지, 매도 요청인지 구분하기 위해 isBuy 라는 boolean 값을 
같이 보내줘서 서버 쪽에서 처리할 수 있도록 구현하였습니다.
코인을 모두 팔았을 때 평균 매수가가 0원이 되어야 하는데 평균 매수가가 그대로 남아 있는 오류가 있었습니다.
이 오류를 해결하기 위해 서버 쪽에서 updatedQuantity 가 0이 되면 평균매수가를 0원으로 처리할 수 있도록 분기처리 해주었습니다.

**기타**
궁금하신 게 있다면 언제든지 말씀해주세요 ~~!!!!